### PR TITLE
Background outline

### DIFF
--- a/src/Behat/Gherkin/Loader/ArrayLoader.php
+++ b/src/Behat/Gherkin/Loader/ArrayLoader.php
@@ -119,7 +119,23 @@ class ArrayLoader implements LoaderInterface
 
         $steps = $this->loadStepsHash($hash['steps']);
 
-        return new BackgroundNode($hash['title'], $steps, $hash['keyword'], $hash['line']);
+        if (isset($hash['examples']['keyword'])) {
+            $examplesKeyword = $hash['examples']['keyword'];
+            unset($hash['examples']['keyword']);
+        } else {
+            $examplesKeyword = 'Examples';
+        }
+        if (isset($hash['examples'])) {
+            $examplesTable = $hash['examples'];
+        } else {
+            $examplesTable = array();
+        }
+        if (\count($examplesTable) === 0) {
+            $examples = null;
+        } else {
+            $examples = new ExampleTableNode($examplesTable, $examplesKeyword);
+        }
+        return new BackgroundNode($hash['title'], $steps, $hash['keyword'], $hash['line'], $examples);
     }
 
     /**

--- a/src/Behat/Gherkin/Loader/YamlFileLoader.php
+++ b/src/Behat/Gherkin/Loader/YamlFileLoader.php
@@ -11,7 +11,6 @@
 namespace Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\OutlineNode;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -58,13 +57,6 @@ class YamlFileLoader extends AbstractFileLoader
         $filename = $this->findRelativePath($path);
 
         return array_map(function (FeatureNode $feature) use ($filename) {
-            if ($feature->getBackground() !== null && $feature->getBackground()->hasExamples()) {
-                foreach ($feature->getScenarios() as $scenario) {
-                    if ($scenario instanceof OutlineNode && !$scenario->hasExamples()){
-                        $scenario->setExampleTable($feature->getBackground()->getExamples());
-                    }
-                }
-            }
             return new FeatureNode(
                 $feature->getTitle(),
                 $feature->getDescription(),

--- a/src/Behat/Gherkin/Loader/YamlFileLoader.php
+++ b/src/Behat/Gherkin/Loader/YamlFileLoader.php
@@ -11,6 +11,7 @@
 namespace Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\OutlineNode;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -57,6 +58,13 @@ class YamlFileLoader extends AbstractFileLoader
         $filename = $this->findRelativePath($path);
 
         return array_map(function (FeatureNode $feature) use ($filename) {
+            if ($feature->getBackground() !== null && $feature->getBackground()->hasExamples()) {
+                foreach ($feature->getScenarios() as $scenario) {
+                    if ($scenario instanceof OutlineNode && !$scenario->hasExamples()){
+                        $scenario->setExampleTable($feature->getBackground()->getExamples());
+                    }
+                }
+            }
             return new FeatureNode(
                 $feature->getTitle(),
                 $feature->getDescription(),

--- a/src/Behat/Gherkin/Node/BackgroundNode.php
+++ b/src/Behat/Gherkin/Node/BackgroundNode.php
@@ -33,6 +33,10 @@ class BackgroundNode implements ScenarioLikeInterface
      * @var integer
      */
     private $line;
+    /**
+     * @var ExampleTableNode
+     */
+    private $exampleTable;
 
     /**
      * Initializes background.
@@ -41,13 +45,15 @@ class BackgroundNode implements ScenarioLikeInterface
      * @param StepNode[]  $steps
      * @param string      $keyword
      * @param integer     $line
+     * @param null|ExampleTableNode $exampleTable
      */
-    public function __construct($title, array $steps, $keyword, $line)
+    public function __construct($title, array $steps, $keyword, $line, $exampleTable=null)
     {
         $this->title = $title;
         $this->steps = $steps;
         $this->keyword = $keyword;
         $this->line = $line;
+        $this->exampleTable = $exampleTable;
     }
 
     /**
@@ -108,5 +114,25 @@ class BackgroundNode implements ScenarioLikeInterface
     public function getLine()
     {
         return $this->line;
+    }
+
+    /**
+     * Returns if background has ExampleTable
+     *
+     * @return boolean
+     */
+    public function hasExamples()
+    {
+        return $this->exampleTable !== null;
+    }
+
+    /**
+     * Returns if background has ExampleTable
+     *
+     * @return null|ExampleTableNode
+     */
+    public function getExamples()
+    {
+        return $this->exampleTable;
     }
 }

--- a/src/Behat/Gherkin/Node/OutlineNode.php
+++ b/src/Behat/Gherkin/Node/OutlineNode.php
@@ -49,18 +49,18 @@ class OutlineNode implements ScenarioInterface
     /**
      * Initializes outline.
      *
-     * @param null|string      $title
-     * @param string[]         $tags
-     * @param StepNode[]       $steps
-     * @param ExampleTableNode $table
-     * @param string           $keyword
-     * @param integer          $line
+     * @param null|string           $title
+     * @param string[]              $tags
+     * @param StepNode[]            $steps
+     * @param null|ExampleTableNode $table
+     * @param string                $keyword
+     * @param integer               $line
      */
     public function __construct(
         $title,
         array $tags,
         array $steps,
-        ExampleTableNode $table,
+        $table,
         $keyword,
         $line
     ) {
@@ -151,7 +151,19 @@ class OutlineNode implements ScenarioInterface
      */
     public function hasExamples()
     {
-        return 0 < count($this->table->getColumnsHash());
+        return $this->table !== null && 0 < count($this->table->getRows());
+    }
+
+    /**
+     * Add Example to the outline.
+     *
+     * @param ExampleTableNode
+     *
+     * @return void
+     */
+    public function setExampleTable($table)
+    {
+        $this->table = $table;
     }
 
     /**

--- a/src/Behat/Gherkin/Parser.php
+++ b/src/Behat/Gherkin/Parser.php
@@ -286,8 +286,7 @@ class Parser
                     ));
                 }
             }
-        }
-        if ($background !== null && $background->hasExamples()) {;
+        } else {
             foreach ($scenarios as $scenario) {
                 if ($scenario instanceof OutlineNode && !$scenario->hasExamples()) {
                     $scenario->setExampleTable($background->getExamples());

--- a/tests/Behat/Gherkin/Fixtures/etalons/background_with_outline.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/background_with_outline.yml
@@ -1,5 +1,5 @@
 feature:
-  title:        Feature with background and example
+  title:        Feature with example in the background
   language:     en
   line:         1
   description:  ~
@@ -11,21 +11,18 @@ feature:
     examples:
       6: [login, password]
       7: ['', '']
-      8: [unknown_user, '']
+      8: [unknown_user, 'known_pass']
 
   scenarios:
     -
       type:     outline
-      title:    ~
+      title:    Scenario outline without example table
       line:     10
       steps:
-        - { keyword_type: 'Given', type: 'Given', text: 'a failing step', line: 11 }
+        - { keyword_type: 'Given', type: 'Given', text: 'I browse to the login page', line: 11 }
         - { keyword_type: 'When',  type: 'When',   text: 'I fill in "login" with "<login>"',       line: 12 }
         - { keyword_type: 'When',  type: 'And',    text: 'I fill in "password" with "<password>"', line: 13 }
-      arguments:
-        -
-          type:   table
-          rows:
-            6: [ login, password ]
-            7: [ '' , '' ]
-            8: [ unknown_user , '' ]
+      examples:
+        6: [login, password]
+        7: ['', '']
+        8: [unknown_user, 'known_pass']

--- a/tests/Behat/Gherkin/Fixtures/etalons/background_with_outline.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/background_with_outline.yml
@@ -1,0 +1,31 @@
+feature:
+  title:        Feature with background and example
+  language:     en
+  line:         1
+  description:  ~
+
+  background:
+    line:       3
+    steps:
+      - { keyword_type: Given, type: Given, text: a passing step, line: 4 }
+    examples:
+      6: [login, password]
+      7: ['', '']
+      8: [unknown_user, '']
+
+  scenarios:
+    -
+      type:     outline
+      title:    ~
+      line:     10
+      steps:
+        - { keyword_type: 'Given', type: 'Given', text: 'a failing step', line: 11 }
+        - { keyword_type: 'When',  type: 'When',   text: 'I fill in "login" with "<login>"',       line: 12 }
+        - { keyword_type: 'When',  type: 'And',    text: 'I fill in "password" with "<password>"', line: 13 }
+      arguments:
+        -
+          type:   table
+          rows:
+            6: [ login, password ]
+            7: [ '' , '' ]
+            8: [ unknown_user , '' ]

--- a/tests/Behat/Gherkin/Fixtures/etalons/background_with_outline_multi.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/background_with_outline_multi.yml
@@ -1,5 +1,5 @@
 feature:
-  title:        Feature with background and example
+  title:        Feature with example in background and multiple scenarios
   language:     en
   line:         1
   description:  ~
@@ -11,35 +11,35 @@ feature:
     examples:
       6: [login, password]
       7: ['', '']
-      8: [unknown_user, '']
+      8: [unknown_user, known_pass]
 
   scenarios:
     -
       type:     outline
-      title:    scenario1
+      title:    Scenario outline without example
       line:     10
       steps:
-        - { keyword_type: 'Given', type: 'Given', text: 'a failing step', line: 11 }
+        - { keyword_type: 'Given', type: 'Given', text: 'I have browsed to login page', line: 11 }
         - { keyword_type: 'When',  type: 'When',   text: 'I fill in "login" with "<login>"',       line: 12 }
         - { keyword_type: 'When',  type: 'And',    text: 'I fill in "password" with "<password>"', line: 13 }
       examples:
         6: [ login, password ]
         7: [ '' , '' ]
-        8: [ unknown_user , '' ]
+        8: [ unknown_user , known_pass ]
 
     - type:     scenario
-      title:    scenario2
+      title:    A regular scenario
       line:     15
       steps:
-        - { keyword_type: 'Given', type: 'Given', text: 'a failing step', line: 16 }
+        - { keyword_type: 'Given', type: 'Given', text: 'I have browsed to login page', line: 16 }
         - { keyword_type: 'When',  type: 'When',   text: 'I fill in "login" with "user"',       line: 17 }
         - { keyword_type: 'When',  type: 'And',    text: 'I fill in "password" with "password"', line: 18 }
 
     - type:     outline
-      title:    scenario3
+      title:    Scenario outline with it's own example table
       line:     20
       steps:
-        - { keyword_type: 'Given', type: 'Given', text: 'a failing step', line: 21 }
+        - { keyword_type: 'Given', type: 'Given', text: 'I have browsed to login page', line: 21 }
         - { keyword_type: 'When',  type: 'When',   text: 'I fill in "login" with "<login>"',       line: 22 }
         - { keyword_type: 'When',  type: 'And',    text: 'I fill in "password" with "<password>"', line: 23 }
       examples:

--- a/tests/Behat/Gherkin/Fixtures/etalons/background_with_outline_multi.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/background_with_outline_multi.yml
@@ -1,0 +1,48 @@
+feature:
+  title:        Feature with background and example
+  language:     en
+  line:         1
+  description:  ~
+
+  background:
+    line:       3
+    steps:
+      - { keyword_type: Given, type: Given, text: a passing step, line: 4 }
+    examples:
+      6: [login, password]
+      7: ['', '']
+      8: [unknown_user, '']
+
+  scenarios:
+    -
+      type:     outline
+      title:    scenario1
+      line:     10
+      steps:
+        - { keyword_type: 'Given', type: 'Given', text: 'a failing step', line: 11 }
+        - { keyword_type: 'When',  type: 'When',   text: 'I fill in "login" with "<login>"',       line: 12 }
+        - { keyword_type: 'When',  type: 'And',    text: 'I fill in "password" with "<password>"', line: 13 }
+      examples:
+        6: [ login, password ]
+        7: [ '' , '' ]
+        8: [ unknown_user , '' ]
+
+    - type:     scenario
+      title:    scenario2
+      line:     15
+      steps:
+        - { keyword_type: 'Given', type: 'Given', text: 'a failing step', line: 16 }
+        - { keyword_type: 'When',  type: 'When',   text: 'I fill in "login" with "user"',       line: 17 }
+        - { keyword_type: 'When',  type: 'And',    text: 'I fill in "password" with "password"', line: 18 }
+
+    - type:     outline
+      title:    scenario3
+      line:     20
+      steps:
+        - { keyword_type: 'Given', type: 'Given', text: 'a failing step', line: 21 }
+        - { keyword_type: 'When',  type: 'When',   text: 'I fill in "login" with "<login>"',       line: 22 }
+        - { keyword_type: 'When',  type: 'And',    text: 'I fill in "password" with "<password>"', line: 23 }
+      examples:
+        25: [ login, password ]
+        26: [ hello, world ]
+        27: [ user , pass ]

--- a/tests/Behat/Gherkin/Fixtures/features/background_with_outline.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/background_with_outline.feature
@@ -1,13 +1,13 @@
-Feature: Feature with background and example
+Feature: Feature with example in the background
 
   Background:
     Given a passing step
     Examples:
-      | login | password |
-      |       |          |
-      | unknown_user |   |
+      | login        | password   |
+      |              |            |
+      | unknown_user | known_pass |
 
-  Scenario Outline:
-    Given a failing step
+  Scenario Outline: Scenario outline without example table
+    Given I browse to the login page
     When I fill in "login" with "<login>"
     And I fill in "password" with "<password>"

--- a/tests/Behat/Gherkin/Fixtures/features/background_with_outline.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/background_with_outline.feature
@@ -1,0 +1,13 @@
+Feature: Feature with background and example
+
+  Background:
+    Given a passing step
+    Examples:
+      | login | password |
+      |       |          |
+      | unknown_user |   |
+
+  Scenario Outline:
+    Given a failing step
+    When I fill in "login" with "<login>"
+    And I fill in "password" with "<password>"

--- a/tests/Behat/Gherkin/Fixtures/features/background_with_outline_multi.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/background_with_outline_multi.feature
@@ -1,24 +1,24 @@
-Feature: Feature with background and example
+Feature: Feature with example in background and multiple scenarios
 
   Background:
     Given a passing step
     Examples:
-      | login | password |
-      |       |          |
-      | unknown_user |   |
+      | login        | password   |
+      |              |            |
+      | unknown_user | known_pass |
 
-  Scenario Outline: scenario1
-    Given a failing step
+  Scenario Outline: Scenario outline without example
+    Given I have browsed to login page
     When I fill in "login" with "<login>"
     And I fill in "password" with "<password>"
 
-  Scenario: scenario2
-    Given a failing step
+  Scenario: A regular scenario
+    Given I have browsed to login page
     When I fill in "login" with "user"
     And I fill in "password" with "password"
 
-  Scenario Outline: scenario3
-    Given a failing step
+  Scenario Outline: Scenario outline with it's own example table
+    Given I have browsed to login page
     When I fill in "login" with "<login>"
     And I fill in "password" with "<password>"
     Examples:

--- a/tests/Behat/Gherkin/Fixtures/features/background_with_outline_multi.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/background_with_outline_multi.feature
@@ -1,0 +1,27 @@
+Feature: Feature with background and example
+
+  Background:
+    Given a passing step
+    Examples:
+      | login | password |
+      |       |          |
+      | unknown_user |   |
+
+  Scenario Outline: scenario1
+    Given a failing step
+    When I fill in "login" with "<login>"
+    And I fill in "password" with "<password>"
+
+  Scenario: scenario2
+    Given a failing step
+    When I fill in "login" with "user"
+    And I fill in "password" with "password"
+
+  Scenario Outline: scenario3
+    Given a failing step
+    When I fill in "login" with "<login>"
+    And I fill in "password" with "<password>"
+    Examples:
+      | login | password |
+      | hello | world    |
+      | user  | pass     |

--- a/tests/Behat/Gherkin/Loader/ArrayLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/ArrayLoaderTest.php
@@ -217,7 +217,8 @@ class ArrayLoaderTest extends \PHPUnit_Framework_TestCase
                         'steps' => array(
                             array('type' => 'Gangway!', 'keyword_type' => 'Given', 'text' => 'bg step 1', 'line' => 3),
                             array('type' => 'Blimey!', 'keyword_type' => 'When', 'text' => 'bg step 2')
-                        )
+                        ),
+                        'examples' => null
                     ),
                     'scenarios' => array(
                         array(
@@ -326,7 +327,8 @@ class ArrayLoaderTest extends \PHPUnit_Framework_TestCase
                                     )
                                 )
                             )
-                        )
+                        ),
+                        'examples' => null
                     )
                 )
             )


### PR DESCRIPTION
Add Support for Outline table in Background.
The Example table provided in the background will be used in all the Scenario outline in that feature unless it is overridden in the scenario outline itself

```Gherkin
@api @skipOnOcV10.3
Feature: Users sync

  Background:
    Given these users have been created with default attributes and without skeleton files:
    | username |
    | user0    |
    | user1    |
  Examples:
    | ocs-api-version | http-status-code |
    | 1               | 200              |
    | 2               | 404              |

  @TestAlsoOnExternalUserBackend
  Scenario Outline: Trying to sync a user which does not exist
    Given using OCS API version "<ocs-api-version>"
    When the administrator tries to sync user "user10" using the OCS API
    Then the HTTP status code should be "<http-status-code>"
    And the OCS status code should be "404"
    And the OCS status message should be "User is not known in any user backend: user10"

  @TestAlsoOnExternalUserBackend
  Scenario: Trying to sync a user as another user which does not exist
    Given using OCS API version "1"
    When user "user20" tries to sync user "user1" using the OCS API
    Then the HTTP status code should be "401"
    And the OCS status code should be "997"
    And the OCS status message should be "Unauthorised"


  @TestAlsoOnExternalUserBackend
  Scenario Outline: Trying to sync a user by non admin user
    Given using OCS API version "<ocs-api-version>"
    When user "user0" tries to sync user "user1" using the OCS API
    Then the HTTP status code should be "<http-status-code>"
    And the OCS status code should be "<ocs-status-code>"
    And the OCS status message should be "Logged in user must be an admin"
    Examples:
      | ocs-api-version | ocs-status-code | http-status-code |
      | 1               | 403             | 200              |
      | 2               | 403             | 403              |
```

### In the above example,
-  The first Scenario will use example table from the background as it is outline and it doesn't have its own example table.
-  The second Scenario will not use any example table as it is not a outline.
-  The third Scenario will use example table provided in the scenario itself as it is outline and it has its own example table.